### PR TITLE
Add module init function and module exit

### DIFF
--- a/Source_code/Makefile
+++ b/Source_code/Makefile
@@ -3,9 +3,7 @@ USER_PROG=bulb
 
 .PHONY: clean driver prog clean
 
-all:
-	make -C $(KERNEL_DRIVER)
-	make -C $(USER_PROG)
+all: driver prog
 
 driver:
 	make -C $(KERNEL_DRIVER)

--- a/Source_code/Makefile
+++ b/Source_code/Makefile
@@ -1,16 +1,12 @@
 KERNEL_DRIVER=dev_gpio
 USER_PROG=bulb
+TARGETS=all clean
+SUBDIRS = $(KERNEL_DRIVER) $(USER_PROG)
+export CURR_KERNEL_DIR=$(PWD)/$(KERNEL_DRIVER)
 
-.PHONY: clean driver prog clean
 
-all: driver prog
+$(TARGETS): $(SUBDIRS)
+$(SUBDIRS):
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 
-driver:
-	make -C $(KERNEL_DRIVER)
-
-prog:
-	make -C $(USER_PROG)
-
-clean:
-	make -C $(KERNEL_DRIVER) clean
-	make -C $(USER_PROG) clean
+.PHONY: $(TARGETS) $(SUBDIRS)

--- a/Source_code/dev_gpio/Makefile
+++ b/Source_code/dev_gpio/Makefile
@@ -1,12 +1,15 @@
 TARGET=dev_gpio
 SRC=./src
-
 obj-m +=$(SRC)/$(TARGET).o
+
+ifndef CURR_KERNEL_DIR
+	CURR_KERNEL_DIR=$(PWD)
+endif
 
 .PHONY: clean
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(CURR_KERNEL_DIR) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(CURR_KERNEL_DIR) clean

--- a/Source_code/dev_gpio/Makefile
+++ b/Source_code/dev_gpio/Makefile
@@ -1,5 +1,4 @@
 TARGET=dev_gpio
-
 SRC=./src
 
 obj-m +=$(SRC)/$(TARGET).o

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -1,15 +1,23 @@
 #include <linux/init.h>
 #include <linux/module.h>
+#include <linux/device.h>
 #include <linux/kernel.h>
 #include <linux/fs.h>
 #include <asm/uaccess.h>
 
 MODULE_LICENSE("GPL");
-MODULE_AUTHOR("Example");
+MODULE_AUTHOR("Bulbs");
 MODULE_DESCRIPTION("gpio");
-MODULE_VERSION("0.01");
+MODULE_VERSION("1.0");
 
 #define DEVICE_NAME "gpio"
+#define CLASS_NAME "gpio"
+/*
+Device class variables
+*/
+static struct class* gpio_class = NULL;
+static struct device* gpio_device = NULL;
+
 
 /*
 Device functions
@@ -66,17 +74,49 @@ static int __init dev_gpio_init(void){
 	major_num = register_chrdev(0, DEVICE_NAME, &file_ops);
 	if (major_num < 0){
 		//Failed to regiser device
-		printk(KERN_ALERT "Failed to register device %d.\n", major_num);
-	} else {
-		return 0;
+		printk(KERN_ALERT "Failed to register device %s major number.\n", DEVICE_NAME);
+		return major_num;
 	}
+	printk(KERN_ALERT "%s device registered correctly with major \
+		number %d\n",DEVICE_NAME, major_num );
+
+	// Register device class with udev
+	gpio_class = class_create(THIS_MODULE, CLASS_NAME);
+
+	// Error creating device class
+	if(IS_ERR(gpio_class)){
+		unregister_chrdev(major_num, DEVICE_NAME);
+		printk(KERN_ALERT "Failed to create device class %s\n", CLASS_NAME);
+		return PTR_ERR(gpio_class);
+	}
+
+	printk(KERN_INFO "%s device class registered correctly\n", CLASS_NAME);
+
+	// Register device driver
+	gpio_device = device_create(gpio_class, NULL, MKDEV(major_num, 0),
+			NULL, DEVICE_NAME);
+
+	//Error creating device and registering device driver
+	if(IS_ERR(gpio_device)){
+		class_destroy(gpio_class); //clean up created device class
+		unregister_chrdev(major_num, DEVICE_NAME);
+		printk(KERN_ALERT "Failed to create device %s\n", DEVICE_NAME);
+		return PTR_ERR(gpio_device);
+	}
+	printk(KERN_INFO "%s device created correctly\n", DEVICE_NAME);
 	return 0;
 }
 
 static void __exit dev_gpio_exit(void){
-	printk(KERN_INFO "Goodbye My kernel\n");
+	//Remove the device
+	device_destroy(gpio_class, MKDEV(major_num, 0));
+	//Unregister device class
+	class_unregister(gpio_class);
+	//Remove the device class
+	class_destroy(gpio_class);
+ 	printk(KERN_INFO "Goodbye %s\n", DEVICE_NAME);
 	unregister_chrdev(major_num, DEVICE_NAME);
-	printk(KERN_INFO "Goodbye, World!\n");
+	printk(KERN_INFO "Goodbye, %s\n", DEVICE_NAME);
 }
 
 module_init(dev_gpio_init);

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -7,16 +7,16 @@
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Bulbs");
-MODULE_DESCRIPTION("gpio");
+MODULE_DESCRIPTION("dev gpio");
 MODULE_VERSION("1.0");
 
-#define DEVICE_NAME "gpio"
-#define CLASS_NAME "gpio"
+#define DEVICE_NAME "dev_gpio"
+#define CLASS_NAME "dev_gpio"
 /*
 Device class variables
 */
-static struct class* gpio_class = NULL;
-static struct device* gpio_device = NULL;
+static struct class* dev_gpio_class = NULL;
+static struct device* dev_gpio_device = NULL;
 
 
 /*
@@ -68,7 +68,7 @@ static int device_release(struct inode *inode, struct file *file){
 }
 
 static int __init dev_gpio_init(void){
-	printk(KERN_INFO "gpio\n");
+	printk(KERN_INFO "%s\n", DEVICE_NAME);
 
 	/*Register character device*/
 	major_num = register_chrdev(0, DEVICE_NAME, &file_ops);
@@ -77,31 +77,31 @@ static int __init dev_gpio_init(void){
 		printk(KERN_ALERT "Failed to register device %s major number.\n", DEVICE_NAME);
 		return major_num;
 	}
-	printk(KERN_ALERT "%s device registered correctly with major \
+	printk(KERN_INFO "%s device registered correctly with major \
 		number %d\n",DEVICE_NAME, major_num );
 
 	// Register device class with udev
-	gpio_class = class_create(THIS_MODULE, CLASS_NAME);
+	dev_gpio_class = class_create(THIS_MODULE, CLASS_NAME);
 
 	// Error creating device class
-	if(IS_ERR(gpio_class)){
+	if(IS_ERR(dev_gpio_class)){
 		unregister_chrdev(major_num, DEVICE_NAME);
 		printk(KERN_ALERT "Failed to create device class %s\n", CLASS_NAME);
-		return PTR_ERR(gpio_class);
+		return PTR_ERR(dev_gpio_class);
 	}
 
 	printk(KERN_INFO "%s device class registered correctly\n", CLASS_NAME);
 
 	// Register device driver
-	gpio_device = device_create(gpio_class, NULL, MKDEV(major_num, 0),
+	dev_gpio_device = device_create(dev_gpio_class, NULL, MKDEV(major_num, 0),
 			NULL, DEVICE_NAME);
 
 	//Error creating device and registering device driver
-	if(IS_ERR(gpio_device)){
-		class_destroy(gpio_class); //clean up created device class
+	if(IS_ERR(dev_gpio_device)){
+		class_destroy(dev_gpio_class); //clean up created device class
 		unregister_chrdev(major_num, DEVICE_NAME);
 		printk(KERN_ALERT "Failed to create device %s\n", DEVICE_NAME);
-		return PTR_ERR(gpio_device);
+		return PTR_ERR(dev_gpio_device);
 	}
 	printk(KERN_INFO "%s device created correctly\n", DEVICE_NAME);
 	return 0;
@@ -109,11 +109,11 @@ static int __init dev_gpio_init(void){
 
 static void __exit dev_gpio_exit(void){
 	//Remove the device
-	device_destroy(gpio_class, MKDEV(major_num, 0));
+	device_destroy(dev_gpio_class, MKDEV(major_num, 0));
 	//Unregister device class
-	class_unregister(gpio_class);
+	class_unregister(dev_gpio_class);
 	//Remove the device class
-	class_destroy(gpio_class);
+	class_destroy(dev_gpio_class);
  	printk(KERN_INFO "Goodbye %s\n", DEVICE_NAME);
 	unregister_chrdev(major_num, DEVICE_NAME);
 	printk(KERN_INFO "Goodbye, %s\n", DEVICE_NAME);


### PR DESCRIPTION
This pull request is for issues #17 and #18

**Testing Instructions**
To test that the module loads and unloads correctly , run the following commands:

```
make
sudo insmod dev_gpio/src/dev_gpio.ko
sudo lsmod | grep "dev_gpio"
sudo dmesg
sudo rmmod dev_gpio
sudo dmesg
```

The above commands do as follows:
`make` builds the kernel module
`insmod` inserts the kernel module into the kernel
`lsmod` lists all kernel modules currently loaded into the kernel
`grep` parses command output for the word "dev_gpio"
`rmmod` removes the loaded kernel module from the kernel
`dmesg` displays the system/kernel logs