### PR TITLE
Add gpio read ioctl

### DIFF
--- a/Source_code/dev_gpio/include/dev_gpio.h
+++ b/Source_code/dev_gpio/include/dev_gpio.h
@@ -5,8 +5,8 @@
 #define GENERIC_ERROR -1
 
 // Define IOC commands
-#define DEV_GPIO_IOC_MAGIC  'K'
+#define DEV_GPIO_IOC_MAGIC  'Z'
 #define DEV_GPIO_IOC_RESET  _IO(DEV_GPIO_IOC_MAGIC, 0)
-#define DEV_GPIO_IOC_READ   _IOR(DEV_GPIO_IOC_MAGIC, 1, unsigned int)
+#define DEV_GPIO_IOC_READ   _IOR(DEV_GPIO_IOC_MAGIC, 1, unsigned long *)
 
 #endif //DEV_GPIO_H

--- a/Source_code/dev_gpio/include/dev_gpio.h
+++ b/Source_code/dev_gpio/include/dev_gpio.h
@@ -1,13 +1,9 @@
-
 #ifndef DEV_GPIO_H
 #define DEV_GPIO_H
 
-// define IOC commands 
+// define IOC commands
 #define DEV_GPIO_IOC_MAGIC  'K'
-#define DEV_GPIO_IOC_RESET    _IO(GPIO_DEV_IOC_MAGIC, 0)
-
-
-
-
+#define DEV_GPIO_IOC_RESET    _IO(DEV_GPIO_IOC_MAGIC, 0)
+#define DEV_GPIO_IOC_READ     _IOR(DEV_GPIO_IOC_MAGIC, 1, int)
 
 #endif // End of DEV_GPIO_H

--- a/Source_code/dev_gpio/include/dev_gpio.h
+++ b/Source_code/dev_gpio/include/dev_gpio.h
@@ -1,9 +1,12 @@
 #ifndef DEV_GPIO_H
 #define DEV_GPIO_H
 
-// define IOC commands
-#define DEV_GPIO_IOC_MAGIC  'K'
-#define DEV_GPIO_IOC_RESET    _IO(DEV_GPIO_IOC_MAGIC, 0)
-#define DEV_GPIO_IOC_READ     _IOR(DEV_GPIO_IOC_MAGIC, 1, int)
+// Define error
+#define GENERIC_ERROR -1
 
-#endif // End of DEV_GPIO_H
+// Define IOC commands
+#define DEV_GPIO_IOC_MAGIC  'K'
+#define DEV_GPIO_IOC_RESET  _IO(DEV_GPIO_IOC_MAGIC, 0)
+#define DEV_GPIO_IOC_READ   _IOR(DEV_GPIO_IOC_MAGIC, 1, unsigned int)
+
+#endif //DEV_GPIO_H

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -6,4 +6,10 @@
 
 // GPIO offset for GPLEV (read state) registers
 #define GPIO_GPLEV_OFFSET 0x34
+
+//GPIO register size
+#define GPIO_REG_SIZE 0x4
+
+//GPIO PIN count
+#define GPIO_PIN_COUNT 54
 #endif //GPIO_H

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -12,4 +12,5 @@
 
 //GPIO PIN count
 #define GPIO_PIN_COUNT 54
+
 #endif //GPIO_H

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -1,0 +1,6 @@
+#ifndef GPIO_H
+#define GPIO_H
+
+// GPIOPhysical base address
+#define GPIO_BASE 0x3f200000
+#endif //GPIO_H

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -1,6 +1,9 @@
 #ifndef GPIO_H
 #define GPIO_H
 
-// GPIOPhysical base address
+// GPIO Physical base address
 #define GPIO_BASE 0x3f200000
+
+// GPIO offset for GPLEV (read state) registers
+#define GPIO_GPLEV_OFFSET 0x34
 #endif //GPIO_H

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -23,6 +23,7 @@ static struct device* dev_gpio_device = NULL;
 
 
 /*
+TODO: Move to dev_gpio.h
 Device functions
 */
 long devgpio_ioctl (struct file *,unsigned int, unsigned long);
@@ -30,6 +31,22 @@ static int device_open(struct inode *, struct file *);
 static int device_release(struct inode *, struct file *);
 static ssize_t device_read(struct file *, char *, size_t, loff_t *);
 static ssize_t device_write(struct file *, const char *, size_t, loff_t *);
+
+/*
+TODO: Move to dev_gpio.h
+Internal implementations of device functions
+*/
+int _ioctl_read_pin(unsigned int pin_num);
+
+/*
+TODO: Move function to debug.c file
+*/
+void int_to_bin(uint32_t num){
+  for (uint32_t ctr = 1 << 31; ctr > 0; ctr = ctr / 2){
+    (num & ctr)? printk("1"): printk("0");
+  }
+  printk("\n");
+}
 
 static int major_num = 0;
 static int device_open_count = 0;
@@ -43,6 +60,22 @@ static struct file_operations file_ops = {
 	.open = device_open,
 	.release = device_release
 	};
+
+//Reads from the specified ioctl pin.
+//Assumes that the pin number is the physical pin number on the board
+// in the pinout diagram
+//Returns 0 or 1 as the value, or -1 if error
+int _ioctl_read_pin(unsigned int pin_num){
+
+	//Check if pin is part of first or second set of pin level registers
+
+	//Create pin mask and calculate shift amount to convert to bit 0 in int
+
+	//Request memory region using request_mem_region
+
+	//Release memory region using release_mem_region
+	//return result
+}
 
 static ssize_t device_read(struct file *flip, char *buffer, size_t len, loff_t *offset){
 	return 0;
@@ -153,6 +186,7 @@ long devgpio_ioctl (struct file *filp,
 		case DEV_GPIO_IOC_RESET:
 			break;
 		case DEV_GPIO_IOC_READ:
+
 			break;
 		default:
 		return -ENOTTY;

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -4,7 +4,8 @@
 #include <linux/kernel.h>
 #include <linux/fs.h>
 #include <asm/uaccess.h>
-#include "../include/dev_gpio.h"												// IOCTL and other definitions here
+#include "../include/dev_gpio.h"		// IOCTL and other definitions here
+#include "../include/gpio.h"
 
 
 MODULE_LICENSE("GPL");
@@ -54,19 +55,19 @@ static ssize_t device_write(struct file *flip, const char *buffer, size_t len, l
 static int device_open(struct inode *inode, struct file *file){
 	//Check if device is already open
 	if(device_open_count){
-		
+
 		printk(KERN_ALERT"device is open by %d devices \n", device_open_count);
-	
+
 	}
 	else
 	{
 	printk(KERN_INFO"GPIO device open by you first \n");
 	}
 	device_open_count++;
-	printk(KERN_INFO "device count = %d \n" , device_open_count); 
+	printk(KERN_INFO "device count = %d \n" , device_open_count);
 	try_module_get(THIS_MODULE);
 	return 0;
-	
+
 }
 
 /*Called when device is closed*/
@@ -75,7 +76,7 @@ static int device_release(struct inode *inode, struct file *file){
 	device_open_count--;
 	module_put(THIS_MODULE);
 	printk(KERN_INFO"GPIO device released \n");
-	printk(KERN_INFO "device count = %d \n" , device_open_count); 
+	printk(KERN_INFO "device count = %d \n" , device_open_count);
 	return 0;
 }
 
@@ -138,7 +139,7 @@ long devgpio_ioctl (struct file *filp,
 
 	int err = 0;
 	if (_IOC_TYPE(cmd) != DEV_GPIO_IOC_MAGIC) return -ENOTTY;
-	
+
 	// checking if the memory pointer specified can be written by the driver.
 	if (_IOC_DIR(cmd) & _IOC_READ)
 		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
@@ -146,15 +147,18 @@ long devgpio_ioctl (struct file *filp,
 		err =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 	if (err)
 		return -EFAULT;
-		
-		
+
+
 	switch(cmd) {
-		
+		case DEV_GPIO_IOC_RESET:
+			break;
+		case DEV_GPIO_IOC_READ:
+			break;
 		default:
 		return -ENOTTY;
 	}
-	
-	
-}	
+
+
+}
 module_init(dev_gpio_init);
 module_exit(dev_gpio_exit);


### PR DESCRIPTION
**Description**
This pull request implements the ioctl read pin command. The read pin command takes a `int *` for the pin number to be read.

**Test Instructions**
Place dev_gpio module source code on device, then run
the following to insert the kernel module and create the `dev_gpio` device

```
cd Source_code/dev_gpio
make
sudo insmod src/dev_gpio.ko
```

Next, enable desired pin using existing gpio interface in bash.
The below example enables pin 2 and sets its state to 0
```
echo 2 > /sys/class/gpio/export
echo out > /sys/class/gpio/gpio2/direction
echo 0 > /sys/class/gpio/gpio2/value
```

Next, compile the below user program that uses the ioctl read pin command:
```
#include<stdlib.h>
#include<stdio.h>
#include<sys/ioctl.h>
#include<fcntl.h>
#include<errno.h>
#include "./include/dev_gpio.h"

#define DEVICE_NAME "/dev/dev_gpio"
int main(int argc, char ** argv){

  int dev_fd = open(DEVICE_NAME, O_RDONLY);

  if(dev_fd < 0){
      printf("Error opening file\n");
      goto leave;
  }

  unsigned int pin = 2;
  int ret = ioctl(dev_fd, DEV_GPIO_IOC_READ, &pin);
  printf("Return code %d", ret);

  leave:
    return 0;
}
```

Run the above program and view the kernel device logs by running the following command: `dmesg`

You should see that the pin state detected is correct.

Try changing the pin state to 1 by running the below code:
```
echo 1 > /sys/class/gpio/gpio2/value
```

And re-run the user program. The pin state returned should be 1 as evident in the user program and logs in `dmesg`

**Testing Tips**
Consider testing this on pin numbers less than 31 and greater than 31 to ensure that the program is using the correct register
