### PR TITLE
21/set gpio pin direction

### DIFF
--- a/Source_code/dev_gpio/Makefile
+++ b/Source_code/dev_gpio/Makefile
@@ -1,8 +1,9 @@
-TARGET=dev_gpio
+TARGET=devgpio
+MAIN=dev_gpio
 GPIO=gpio
 SRC=./src
-obj-m+=$(SRC)/$(TARGET).o 
-dev_gpio-objs+=$(SRC)/$(GPIO).o
+obj-m += $(TARGET).o
+$(TARGET)-objs := $(SRC)/$(GPIO).o $(SRC)/$(MAIN).o
 
 ifndef CURR_KERNEL_DIR
 	CURR_KERNEL_DIR=$(PWD)

--- a/Source_code/dev_gpio/Makefile
+++ b/Source_code/dev_gpio/Makefile
@@ -1,6 +1,8 @@
 TARGET=dev_gpio
+GPIO=gpio
 SRC=./src
-obj-m +=$(SRC)/$(TARGET).o
+obj-m+=$(SRC)/$(TARGET).o 
+dev_gpio-objs+=$(SRC)/$(GPIO).o
 
 ifndef CURR_KERNEL_DIR
 	CURR_KERNEL_DIR=$(PWD)

--- a/Source_code/dev_gpio/include/dev_gpio.h
+++ b/Source_code/dev_gpio/include/dev_gpio.h
@@ -9,6 +9,7 @@
 #define DEV_GPIO_IOC_RESET  _IO(DEV_GPIO_IOC_MAGIC, 0)
 #define DEV_GPIO_IOC_READ   _IOR(DEV_GPIO_IOC_MAGIC, 1, unsigned long *)
 #define DEV_GPIO_IOC_WRITE   _IOR(DEV_GPIO_IOC_MAGIC, 2, unsigned long *)
+#define DEV_GPIO_IOC_CHANGEDIR  _IOR(DEV_GPIO_IOC_MAGIC, 3, unsigned long *)
 
 /*
 Internal implementations of device functions
@@ -23,13 +24,25 @@ int _ioctl_read_pin(unsigned int pin_num);
 /*
 Internal implementations of device functions
 
-pin_num: The pin value to write to is in the first bit,
+pin_arg: The pin value to write to is in the first bit,
 The pin number is represented as a value contained in bytes 8-15
 
 Returns:
 Returns 0 for success or -1 for error
 */
 int _ioctl_write_pin(unsigned int pin_arg);
+
+
+/*
+Internal implementations of device functions
+
+pin_arg: The pin direction (0 for in, 1 for out) is in the first bit,
+The pin number is represented as a value contained in bytes 8-15
+
+Returns:
+Returns 0 for success or -1 for error
+*/
+int _ioctl_change_pin_dir(unsigned int pin_arg);
 
 long devgpio_ioctl (struct file *,unsigned int, unsigned long);
 static int device_open(struct inode *, struct file *);

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -16,6 +16,31 @@
 //GPIO register size
 #define GPIO_REG_SIZE 0x4
 
+//GPIO offset for GPFSEL0 pins 0 - 9
+#define GPIO_GPFSEL0_OFFSET 0x00
+
+//GPIO offset for GPFSEL1 pins  10 - 19
+#define GPIO_GPFSEL1_OFFSET 0x04
+
+//Checks if GPFSEL0 applies to x
+#define IN_RANGE_GPFSEL0(x) (x <= 9 && x >= 0)
+
+//Checks if GPFSEL1 applies to x
+#define IN_RANGE_GPFSEL1(x) (x <= 19 && x >= 10)
+
+//Determine bit start position of pin for GPFSEL register
+#define GPIO_GPFSEL_POS(x, pos)  
+	if (IN_RANGE_GPFSEL0(x)) 
+		pos = (2 + x) + 3 * x;
+	else if(IN_RANGE_GPFSEL1(x)) 
+		pos = (2 + (x - 10)) + 3 * (x - 10)
+
+//GPIO value for selecting input mode
+#define GPIO_GPFSEL_IN 0x00
+
+//GPIO value for selecting output mode
+#define GPIO_GPFSEL_OUT 0x01
+
 //GPIO PIN count
 #define GPIO_PIN_COUNT 54
 

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -16,6 +16,9 @@
 //GPIO register size
 #define GPIO_REG_SIZE 0x4
 
+//GPIO GPFSEL bit length
+#define GPIO_GPSEL_FUNC_SIZE 3
+
 //GPIO offset for GPFSEL0 pins 0 - 9
 #define GPIO_GPFSEL0_OFFSET 0x00
 
@@ -28,13 +31,6 @@
 //Checks if GPFSEL1 applies to x
 #define IN_RANGE_GPFSEL1(x) (x <= 19 && x >= 10)
 
-//Determine bit start position of pin for GPFSEL register
-#define GPIO_GPFSEL_POS(x, pos)  
-	if (IN_RANGE_GPFSEL0(x)) 
-		pos = (2 + x) + 3 * x;
-	else if(IN_RANGE_GPFSEL1(x)) 
-		pos = (2 + (x - 10)) + 3 * (x - 10)
-
 //GPIO value for selecting input mode
 #define GPIO_GPFSEL_IN 0x00
 
@@ -43,5 +39,8 @@
 
 //GPIO PIN count
 #define GPIO_PIN_COUNT 54
+
+//Determine bit start position of pin for GPSEL register
+inline int gpio_gpfsel_pos(unsigned int x);
 
 #endif //GPIO_H

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -1,5 +1,9 @@
 #ifndef GPIO_H
 #define GPIO_H
+#include <linux/types.h>
+
+//GPIO PIN count
+#define GPIO_PIN_COUNT 54
 
 // GPIO Physical base address
 #define GPIO_BASE 0x3f200000
@@ -25,11 +29,23 @@
 //GPIO offset for GPFSEL1 pins  10 - 19
 #define GPIO_GPFSEL1_OFFSET 0x04
 
-//Checks if GPFSEL0 applies to x
+//Checks if GPFSEL0 applies to pin x
 #define IN_RANGE_GPFSEL0(x) (x <= 9 && x >= 0)
 
-//Checks if GPFSEL1 applies to x
+//Checks if GPFSEL1 applies to pin x
 #define IN_RANGE_GPFSEL1(x) (x <= 19 && x >= 10)
+
+//Checks if GPFSEL2 applies to pin x
+#define IN_RANGE_GPFSEL2(x) (x <= 29 && x >= 20)
+
+//Checks if GPFSEL3 applies to pin x
+#define IN_RANGE_GPFSEL3(x) (x <= 39 && x >= 30)
+
+//Checks if GPFSEL4 applies to pin x
+#define IN_RANGE_GPFSEL4(x) (x <= 49 && x >= 40)
+
+//Checks if GPFSEL5 applies to pin x
+#define IN_RANGE_GPFSEL5(x) (x <= (GPIO_PIN_COUNT-1) && x >= 50)
 
 //GPIO value for selecting input mode
 #define GPIO_GPFSEL_IN 0x00
@@ -37,10 +53,24 @@
 //GPIO value for selecting output mode
 #define GPIO_GPFSEL_OUT 0x01
 
-//GPIO PIN count
-#define GPIO_PIN_COUNT 54
 
-//Determine bit start position of pin for GPSEL register
-inline int gpio_gpfsel_pos(unsigned int x);
+/*
+Internal implementations of device functions
+
+pin_arg: The pin direction (0 for in, 1 for out) is in the first bit,
+The pin number is represented as a value contained in bytes 8-15
+
+Returns:
+Returns 0 for success or -1 for error
+*/
+int change_pin_dir(uint32_t pin_num, uint32_t pin_dir);
+
+/*Determine bit start position of pin for GPSEL register
+pin: The pin number
+
+Returns:
+Returns the ending index of the pins position
+*/
+inline int gpio_gpfsel_pos(unsigned int pin);
 
 #endif //GPIO_H

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -61,9 +61,32 @@ pin_arg: The pin direction (0 for in, 1 for out) is in the first bit,
 The pin number is represented as a value contained in bytes 8-15
 
 Returns:
-Returns 0 for success or -1 for error
+	Returns 0 for success or -1 for error
 */
 int change_pin_dir(uint32_t pin_num, uint32_t pin_dir);
+
+/*
+Internal implementations of device functions
+
+pin_num: The pin value to write to is in the first bit,
+pin_val: The value to write to the pin (0 or 1)
+
+Returns:
+	Returns 0 for success or -1 for error
+*/
+int write_to_pin(uint32_t pin_num, uint32_t pin_val);
+
+/*
+Reads from the specified ioctl pin.
+Assumes that the pin number is the physical pin number on the board
+in the pinout diagram.
+
+pin_num: The pin number to read from
+
+Returns:
+	0 or 1 as the value, or -1 if error
+*/
+int read_pin(uint32_t pin_num);
 
 /*Determine bit start position of pin for GPSEL register
 pin: The pin number

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -59,83 +59,11 @@ Returns:
 Returns 0 for success or -1 for error
 */
 int _ioctl_change_pin_dir(unsigned int pin_arg){
-	uint32_t mask_off = 0;
-	uint32_t zero = 0;
 	uint32_t first_bit = 1;
-	uint32_t pin_mode_pos = 0;
 	uint32_t pin_num = (pin_arg >> 8);
-	uint32_t gpio_base = 0;
-	uint32_t * gpio_virt_mem = NULL;
-	uint32_t pin_reg_val = 0;
-	uint32_t end_idx = 0; // The ending idx for the bits that represent that particular pin in the register
 	uint32_t pin_dir = pin_arg & first_bit; // The direction of the pin (0/1) (in/out)
 	printk(KERN_INFO "Pin input for changing direction: %u", pin_arg);
-
-	//Make sure that pin number is valid
-	if(pin_num >= GPIO_PIN_COUNT){
-		printk(KERN_ALERT "Pin number %u given is invalid", pin_num);
-		return -EINVAL;
-	}
-	printk(KERN_INFO "Attempting to set mode %u to pin %u", pin_dir, pin_num);
-
-	
-	//Set base to approprieate select offset for GPFSEL
-	if (IN_RANGE_GPFSEL0(pin_num)){
-		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL0_OFFSET);
-
-	}else if(IN_RANGE_GPFSEL1(pin_num)){
-		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL1_OFFSET);
-
-	}else{
-		//This should never happen
-		printk(KERN_ALERT "Pin number %u is out of the range for GPFSEL", pin_num);
-		return -EINVAL;
-	}
-
-	printk(KERN_INFO "Successfully requested memory region %x, pin num %u",
-	(unsigned int) gpio_base, pin_num);
-
-	// Even though it is deprecated, since this is an out-of-tree module,
-	// We are using ioremap to request virtual map of physical address
-	// We understand that we need to check if the memory area is being used first but we
-	// are skipping disabling the existing gpio driver
-	gpio_virt_mem = (uint32_t *) ioremap(gpio_base, GPIO_REG_SIZE);
-	if(gpio_virt_mem == NULL){
-		printk(KERN_ALERT "Failed to map physical memory to kernel address space");
-		return -EINVAL;
-	}
-
-	printk(KERN_INFO "Successfully mapped physical memory "
-	  		"at %x to kernel address space", gpio_base);
-
-	// Read the contents of the GPFSEL register mapped to virtual memory
-	pin_reg_val = (uint32_t) readw(gpio_virt_mem);
-
-	// Get the correct ending bit position to change
-	end_idx = gpio_gpfsel_pos(pin_num);
-
-	//Change bits at applicable positions and write out register
-	//TODO: make this more independent of underlying gpio implementation
-	mask_off = 0;
-	if(pin_dir == GPIO_GPFSEL_IN){
-		pin_reg_val = pin_reg_val & ~(1 << end_idx);
-		end_idx--;
-		pin_reg_val = pin_reg_val & ~(1 << end_idx);
-		end_idx--;
-		pin_reg_val = pin_reg_val & ~(1 << end_idx);
-
-	}else{ //GPIO pin out direction
-		pin_reg_val = pin_reg_val & ~(1 << end_idx);
-		end_idx--;
-		pin_reg_val = pin_reg_val & ~(1 << end_idx);
-		end_idx--;
-		pin_reg_val = pin_reg_val | (1 << end_idx);
-	}
-
-	//Write the value back to the register with the desired bits set/cleared
-	writew(pin_reg_val, gpio_virt_mem);
-
-	return 0;
+	return change_pin_dir(pin_num, pin_dir);
 }
 
 /*
@@ -433,7 +361,9 @@ long devgpio_ioctl (struct file *filp,
 			break;
 
 		case DEV_GPIO_IOC_CHANGEDIR:
-
+			printk(KERN_INFO "Performing ioctl change pin dir");
+			val = (uint32_t) *((unsigned long*) arg);
+			return_val = _ioctl_change_pin_dir(val);
 			break;
 
 		default:

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -15,8 +15,8 @@ MODULE_AUTHOR("Bulbs");
 MODULE_DESCRIPTION("dev gpio");
 MODULE_VERSION("1.0");
 
-#define DEVICE_NAME "dev_gpio"
-#define CLASS_NAME "dev_gpio"
+#define DEVICE_NAME "devgpio"
+#define CLASS_NAME "devgpio"
 /*
 Device class variables
 */

--- a/Source_code/dev_gpio/src/gpio.c
+++ b/Source_code/dev_gpio/src/gpio.c
@@ -16,10 +16,7 @@ Returns:
 Returns 0 for success or -1 for error
 */
 int change_pin_dir(uint32_t pin_num, uint32_t pin_dir){
-	uint32_t mask_off = 0;
-	uint32_t zero = 0;
 	uint32_t first_bit = 1;
-	uint32_t pin_mode_pos = 0;
 	uint32_t gpio_base = 0;
 	uint32_t * gpio_virt_mem = NULL;
 	uint32_t pin_reg_val = 0;
@@ -70,29 +67,195 @@ int change_pin_dir(uint32_t pin_num, uint32_t pin_dir){
 	printk(KERN_INFO "GPIOSEL ending index: %u\n", end_idx);
 
 	//Change bits at applicable positions and write out register
-	mask_off = 0;
 	if(pin_dir == GPIO_GPFSEL_IN){//GPIO pin in direction
-		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 3rd bit
+		pin_reg_val = pin_reg_val & ~(first_bit << end_idx); //change 3rd bit
 		end_idx--;
-		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 2nd bit
+		pin_reg_val = pin_reg_val & ~(first_bit << end_idx); //change 2nd bit
 		end_idx--;
-		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 1st bit
+		pin_reg_val = pin_reg_val & ~(first_bit << end_idx); //change 1st bit
 
 	}else{ //GPIO pin out direction
-		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 3rd bit
+		pin_reg_val = pin_reg_val & ~(first_bit << end_idx); //change 3rd bit
 		end_idx--;
-		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 2nd bit
+		pin_reg_val = pin_reg_val & ~(first_bit << end_idx); //change 2nd bit
 		end_idx--;
-		pin_reg_val = pin_reg_val | (1 << end_idx); //change 1st bit
+		pin_reg_val = pin_reg_val | (first_bit << end_idx); //change 1st bit
 	}
 
 	//Write the value back to the register with the desired bits set/cleared
 	writew(pin_reg_val, gpio_virt_mem);
 
+	//Unmap Memory
+	iounmap(gpio_virt_mem);
+
 	return 0;
 }
 
 
+/*
+Internal implementations of device functions
+
+pin_num: The pin value to write to is in the first bit,
+pin_val: The value to write to the pin (0 or 1)
+
+Returns:
+Returns 0 for success or -1 for error
+*/
+int write_to_pin(uint32_t pin_num, uint32_t pin_val){
+	uint32_t zero = 0;
+	uint32_t first_bit = 1;
+	uint32_t pin_write = 0;
+	uint32_t gpio_base = 0;
+	uint32_t * gpio_virt_mem = NULL;
+	uint32_t pin_reg_val = 0;
+	uint32_t pin_curr_val = 0;
+
+	//Make sure that pin number is valid
+	if(pin_num >= GPIO_PIN_COUNT){
+		printk(KERN_ALERT "Pin number %u given is invalid", pin_num);
+		return -EINVAL;
+	}
+	printk(KERN_INFO "Attempting to write value %u to pin %u", pin_val, pin_num);
+
+	
+	//Check if GPCLR is to be chosen
+	if (pin_val == 0){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPCLR_OFFSET);
+		pin_val = 1;
+
+	//Check if GPSET is to be chosen
+	}else if (pin_val == 1){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPSET_OFFSET);
+	}
+
+	//Check if pin is part of first or second set of pin level registers
+	if(pin_num >= 32){
+		// Use the second register for the pin count
+		gpio_base += (uint32_t) GPIO_REG_SIZE;
+		//Adjust pin number to match bit position
+		pin_num = pin_num % 32;
+	}
+
+	printk(KERN_INFO "Successfully requested memory region %x, pin num %u",
+	(unsigned int) gpio_base, pin_num);
+
+	// Even though it is deprecated, since this is an out-of-tree module,
+	// We are using ioremap to request virtual map of physical address
+	// We understand that we need to check if the memory area is being used first but we
+	// are skipping disabling the existing gpio driver
+	gpio_virt_mem = (uint32_t *) ioremap(gpio_base, GPIO_REG_SIZE);
+	if(gpio_virt_mem == NULL){
+		printk(KERN_ALERT "Failed to map physical memory to kernel address space");
+		return -EINVAL;
+	}
+
+	printk(KERN_INFO "Successfully mapped physical memory "
+	  		"at %x to kernel address space", gpio_base);
+
+    //Read word containing pin state
+	pin_reg_val = (uint32_t) readw(gpio_virt_mem);
+
+	//Calculate current state of pin, need to shift if pin number is not 0
+	if(pin_num != 0){
+		pin_curr_val = (pin_reg_val >> (pin_num - 1)) ^ zero;
+	}
+
+	printk(KERN_INFO "Current state of pin %u is %u", pin_num, pin_curr_val);
+
+	//Set position to write to
+	pin_write = (first_bit << pin_num);
+
+	//Set bit in read value
+	pin_write = pin_reg_val | pin_write;
+
+	//Write the value back to the register with the desired bit set/cleared
+	writew(pin_write, gpio_virt_mem);
+
+	printk(KERN_INFO "Wrote the value %u to pin %u\n", pin_val, pin_num);
+
+	//Unmap Memory
+	iounmap(gpio_virt_mem);
+
+	return 0;
+}
+
+/*
+Reads from the specified ioctl pin.
+Assumes that the pin number is the physical pin number on the board
+in the pinout diagram.
+
+pin_num: The pin number to read from
+
+Returns:
+	0 or 1 as the value, or -1 if error
+*/
+int read_pin(uint32_t pin_num){
+	uint32_t gpio_gplev_base = (uint32_t) (GPIO_BASE + GPIO_GPLEV_OFFSET);
+	uint32_t * gpio_virt_mem = NULL;
+	int pin_state = 0;
+	uint32_t pin_reg_val = 0;
+
+	//Make sure that pin number is valid
+	if(pin_num >= GPIO_PIN_COUNT){
+		printk(KERN_ALERT "Pin number %u given is invalid", pin_num);
+		return -EINVAL;
+	}
+
+	//Check if pin is part of first or second set of pin level registers
+	if(pin_num >= 32){
+		// Use the second register for the pin count
+		gpio_gplev_base += (uint32_t) GPIO_REG_SIZE;
+		//Adjust pin number to match bit position
+		pin_num = pin_num % 32;
+	}
+
+	//For now, to avoid having to disable buit-in gpio, do not request mem region
+	//I know this is bad practice
+	//Request memory region using request_mem_region
+	/*if(request_mem_region(gpio_gplev_base, GPIO_REG_SIZE, DEVICE_NAME) == NULL){
+		printk(KERN_ALERT "Memory region %x is already requested by another process",
+			(unsigned int) gpio_gplev_base);
+		return -EBUSY;
+	}*/
+
+
+	printk(KERN_INFO "Successfully requested memory region %x, pin num %u",
+		(unsigned int) gpio_gplev_base, pin_num);
+
+	//Even though it is deprecated, since this is an out-of-tree module,
+	// We are using ioremap to request virtual map of physical address
+	gpio_virt_mem = (uint32_t *) ioremap(gpio_gplev_base, GPIO_REG_SIZE);
+	if(gpio_virt_mem == NULL){
+		printk(KERN_ALERT "Failed to map physical memory to kernel address space");
+		return -EINVAL;
+	}
+
+	printk(KERN_INFO "Successfully mapped physical memory "
+	  		"at %x to kernel address space", gpio_gplev_base);
+
+  //Read byte containing pin state
+    pin_reg_val = (uint32_t) readw(gpio_virt_mem);
+
+	//Get correct bit position value
+	pin_state = (pin_reg_val & (1 << pin_num));
+
+	//Covert value at bit position to 0 or 1
+	pin_state = (pin_state >> pin_num);
+
+	printk(KERN_INFO "Pin state read is %d", pin_state);
+
+	//Release memory region using release_mem_region
+	/*release_mem_region(gpio_gplev_base, GPIO_REG_SIZE);
+	printk(KERN_INFO "Successfully released memory region %x",
+		(unsigned int) gpio_gplev_base);
+*/
+
+	//Unmap Memory
+	iounmap(gpio_virt_mem);
+
+	//return result
+	return pin_state;
+}
 
 /*Determine bit start position of pin for GPSEL register
 pin: The pin number

--- a/Source_code/dev_gpio/src/gpio.c
+++ b/Source_code/dev_gpio/src/gpio.c
@@ -1,0 +1,12 @@
+#include "../include/gpio.h"
+
+inline int gpio_gpfsel_pos(unsigned int x){
+	unsigned int result = 0;
+	if (IN_RANGE_GPFSEL0(x)){
+		result = (2 + x) + 3 * x;
+	}else if(IN_RANGE_GPFSEL1(x)){
+		result = (2 + (x - 10)) + 3 * (x - 10);
+	}
+
+	return result;
+}

--- a/Source_code/dev_gpio/src/gpio.c
+++ b/Source_code/dev_gpio/src/gpio.c
@@ -1,11 +1,119 @@
+#include <linux/types.h>
+#include <linux/kernel.h>
+#include <linux/fs.h>
+#include <linux/ioport.h>
+#include <asm/uaccess.h>
+#include <asm/io.h>
 #include "../include/gpio.h"
 
+/*
+Internal implementations of device functions
+
+pin_arg: The pin direction (0 for in, 1 for out) is in the first bit,
+The pin number is represented as a value contained in bytes 8-15
+
+Returns:
+Returns 0 for success or -1 for error
+*/
+int change_pin_dir(uint32_t pin_num, uint32_t pin_dir){
+	uint32_t mask_off = 0;
+	uint32_t zero = 0;
+	uint32_t first_bit = 1;
+	uint32_t pin_mode_pos = 0;
+	uint32_t gpio_base = 0;
+	uint32_t * gpio_virt_mem = NULL;
+	uint32_t pin_reg_val = 0;
+	uint32_t end_idx = 0; // The ending idx for the bits that represent that particular pin in the register
+
+	//Make sure that pin number is valid
+	if(pin_num >= GPIO_PIN_COUNT){
+		printk(KERN_ALERT "Pin number %u given is invalid", pin_num);
+		return -EINVAL;
+	}
+	printk(KERN_INFO "Attempting to set mode %u to pin %u", pin_dir, pin_num);
+
+	
+	//Set base to approprieate select offset for GPFSEL
+	if (IN_RANGE_GPFSEL0(pin_num)){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL0_OFFSET);
+
+	}else if(IN_RANGE_GPFSEL1(pin_num)){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL1_OFFSET);
+
+	}else{
+		//This should never happen
+		printk(KERN_ALERT "Pin number %u is out of the range for GPFSEL", pin_num);
+		return -EINVAL;
+	}
+
+	printk(KERN_INFO "Successfully requested memory region %x, pin num %u",
+	(unsigned int) gpio_base, pin_num);
+
+	// Even though it is deprecated, since this is an out-of-tree module,
+	// We are using ioremap to request virtual map of physical address
+	// We understand that we need to check if the memory area is being used first but we
+	// are skipping disabling the existing gpio driver
+	gpio_virt_mem = (uint32_t *) ioremap(gpio_base, GPIO_REG_SIZE);
+	if(gpio_virt_mem == NULL){
+		printk(KERN_ALERT "Failed to map physical memory to kernel address space");
+		return -EINVAL;
+	}
+
+	printk(KERN_INFO "Successfully mapped physical memory "
+	  		"at %x to kernel address space", gpio_base);
+
+	// Read the contents of the GPFSEL register mapped to virtual memory
+	pin_reg_val = (uint32_t) readw(gpio_virt_mem);
+
+	// Get the correct ending bit position to change
+	end_idx = gpio_gpfsel_pos(pin_num);
+	printk(KERN_INFO "GPIOSEL ending index: %u\n", end_idx);
+
+	//Change bits at applicable positions and write out register
+	mask_off = 0;
+	if(pin_dir == GPIO_GPFSEL_IN){//GPIO pin in direction
+		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 3rd bit
+		end_idx--;
+		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 2nd bit
+		end_idx--;
+		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 1st bit
+
+	}else{ //GPIO pin out direction
+		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 3rd bit
+		end_idx--;
+		pin_reg_val = pin_reg_val & ~(1 << end_idx); //change 2nd bit
+		end_idx--;
+		pin_reg_val = pin_reg_val | (1 << end_idx); //change 1st bit
+	}
+
+	//Write the value back to the register with the desired bits set/cleared
+	writew(pin_reg_val, gpio_virt_mem);
+
+	return 0;
+}
+
+
+
+/*Determine bit start position of pin for GPSEL register
+pin: The pin number
+
+Returns:
+Returns the ending index of the pins position
+*/
 inline int gpio_gpfsel_pos(unsigned int x){
 	unsigned int result = 0;
 	if (IN_RANGE_GPFSEL0(x)){
-		result = (2 + x) + 3 * x;
+		result = 2 + 3 * x;
 	}else if(IN_RANGE_GPFSEL1(x)){
-		result = (2 + (x - 10)) + 3 * (x - 10);
+		result = 2 + 3 * (x - 10);
+	}else if(IN_RANGE_GPFSEL2(x)){
+		result = 2 + 3 * (x - 20);
+	}else if(IN_RANGE_GPFSEL3(x)){
+		result = 2 + 3 * (x - 30);
+	}else if(IN_RANGE_GPFSEL4(x)){
+		result = 2 + 3 * (x - 40);
+	}else if(IN_RANGE_GPFSEL5(x)){
+		result = 2 + 3 * (x - 50);
 	}
 
 	return result;


### PR DESCRIPTION
**Description**
This pull request implements the ioctl change direction pin command. The change direction pin command takes the desired state of the pin (0 (in) or 1 (out)) in bits 0 - 7, and the desired pin number as a value in bits 8 - 15.

**Test Instructions**
Place dev_gpio module source code on device, then run
the following to insert the kernel module and create the `dev_gpio` device

```
cd Source_code/dev_gpio
make
sudo insmod src/dev_gpio.ko
```

Next, enable desired pin using existing gpio interface in bash.
The below example enables pin 2 into userspace
```
echo 2 > /sys/class/gpio/export
```

Next, compile the below user program that uses the ioctl change direction pin command:
```
#include<stdlib.h>
#include<stdio.h>
#include<sys/ioctl.h>
#include<sys/types.h>
#include<fcntl.h>
#include<errno.h>
#include "./dev_gpio/include/dev_gpio.h"

#define DEVICE_NAME "/dev/dev_gpio"
int main(int argc, char ** argv){

  int dev_fd = open(DEVICE_NAME, O_RDONLY);

  if(dev_fd < 0){
      printf("Error opening file\n");
      goto leave;
  }

  u_int32_t pin_num = 2;

  u_int32_t pin = 0;
  pin = (pin_num << 8);
  pin = pin | 1; // Turn direction to out  or change to 0 for in
  printf("Value to pass to ioctl change direction%u", pin);
  int ret = ioctl(dev_fd, DEV_GPIO_IOC_CHANGEDIR, &pin);
  printf("Return change direction status code %d", ret);

  leave:
    return 0;
}
```

Run the above program and view the kernel device logs by running the following command: `dmesg`

You should see that the pin direction change is correct. 

Try viewing the pin direction by running the below code:
```
cat /sys/class/gpio/gpio2/direction
```

And re-run the user program. The pin should be set to in or out depending on the intended direction.

**Testing Tips**
Consider testing this on pin numbers less than 31 and greater than 31 to ensure that the program is using the correct register
