### PR TITLE
5/configure pin from config

### DIFF
--- a/Source_code/bulb/include/bulb.h
+++ b/Source_code/bulb/include/bulb.h
@@ -36,5 +36,15 @@ Returns:
 	Returns 0 on success, else returns -1 on failure
 */
 int init_seven_seg_peripheral(SEVEN_SEG_DISPLAY * seven_display, MAP ini_content[], size_t len);
+
+/*Initializes the board with the configurations stated for the sensors.
+
+inf-sensor: The infrared sensor
+seven_display: The 7 segment cathode display
+
+Returns:
+Returns the file descriptor of the open device file
+*/
+int init_program_board(INFRARED_SENSOR * inf_sensor, SEVEN_SEG_DISPLAY * seven_display);
 //parse_config
 #endif /*BULB_H*/

--- a/Source_code/bulb/src/infrared_fc_51_peripheral.c
+++ b/Source_code/bulb/src/infrared_fc_51_peripheral.c
@@ -27,8 +27,8 @@ Returns:
 	Returns 0 on success, a negative value on failure
 */
 int set_inf_fc51_segment(INFRARED_SENSOR * inf_sensor, char seg, unsigned int value){
-
 	if(value > INF_FC51_MAX_VAL){
+		printf("Cannot set inf sensor %c to value %u. Value exceeds %d\n", seg, value, INF_FC51_MAX_VAL);
 		return -1;
 	}
 
@@ -40,6 +40,7 @@ int set_inf_fc51_segment(INFRARED_SENSOR * inf_sensor, char seg, unsigned int va
 
 		// Invalid segment
 		default:
+			printf("Error inf sensor %c to value %u. Invalid segment\n", seg, value);
 			return -1;
 	}
 	return 0;

--- a/Source_code/dev_gpio/include/dev_gpio.h
+++ b/Source_code/dev_gpio/include/dev_gpio.h
@@ -1,8 +1,12 @@
 #ifndef DEV_GPIO_H
 #define DEV_GPIO_H
-
+#include "gpio.h"
 // Define error
 #define GENERIC_ERROR -1
+
+//Device defs
+#define GPIO_OUT GPIO_GPFSEL_OUT
+#define GPIO_IN GPIO_GPFSEL_IN
 
 // Define IOC commands
 #define DEV_GPIO_IOC_MAGIC  'Z'

--- a/Source_code/dev_gpio/include/gpio.h
+++ b/Source_code/dev_gpio/include/gpio.h
@@ -29,6 +29,18 @@
 //GPIO offset for GPFSEL1 pins  10 - 19
 #define GPIO_GPFSEL1_OFFSET 0x04
 
+//GPIO offset for GPFSEL2 pins  20 - 29
+#define GPIO_GPFSEL2_OFFSET 0x08
+
+//GPIO offset for GPFSEL3 pins  30 - 39
+#define GPIO_GPFSEL3_OFFSET 0x0c
+
+//GPIO offset for GPFSEL4 pins  40 - 49
+#define GPIO_GPFSEL4_OFFSET 0x10
+
+//GPIO offset for GPFSEL5 pins  50 - 53
+#define GPIO_GPFSEL5_OFFSET 0x14
+
 //Checks if GPFSEL0 applies to pin x
 #define IN_RANGE_GPFSEL0(x) (x <= 9 && x >= 0)
 

--- a/Source_code/dev_gpio/src/dev_gpio.c
+++ b/Source_code/dev_gpio/src/dev_gpio.c
@@ -15,6 +15,7 @@ MODULE_AUTHOR("Bulbs");
 MODULE_DESCRIPTION("dev gpio");
 MODULE_VERSION("1.0");
 
+//Device macros
 #define DEVICE_NAME "devgpio"
 #define CLASS_NAME "devgpio"
 /*

--- a/Source_code/dev_gpio/src/gpio.c
+++ b/Source_code/dev_gpio/src/gpio.c
@@ -37,6 +37,17 @@ int change_pin_dir(uint32_t pin_num, uint32_t pin_dir){
 	}else if(IN_RANGE_GPFSEL1(pin_num)){
 		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL1_OFFSET);
 
+	}else if(IN_RANGE_GPFSEL2(pin_num)){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL2_OFFSET);
+
+	}else if(IN_RANGE_GPFSEL3(pin_num)){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL3_OFFSET);
+
+	}else if(IN_RANGE_GPFSEL4(pin_num)){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL4_OFFSET);
+
+	}else if(IN_RANGE_GPFSEL5(pin_num)){
+		gpio_base = (uint32_t) (GPIO_BASE + GPIO_GPFSEL5_OFFSET);
 	}else{
 		//This should never happen
 		printk(KERN_ALERT "Pin number %u is out of the range for GPFSEL", pin_num);


### PR DESCRIPTION
**Description**
This pull request implements the userspace config for configuring the board with the correct configuration for the 7 segment display and infrared sensor

**Test Instructions**
Place dev_gpio module source code and bulb source code on device, then run
the following to insert the kernel module and create the `devgpio` device

```
cd Source_code/dev_gpio
make
sudo insmod src/devgpio.ko
```
Next, compile the bulb source code and create the following config file:
```
cd bulb
make
```

```
[INFRARED_SENSOR]
O_PIN=3
[7_SEG_DISPLAY]
A_PIN=12
B_PIN=13
C_PIN=15
D_PIN=22
E_PIN=23
F_PIN=24
G_PIN=26
```

Run the following command to configure the board based on the above `bulb.config` file:

`sudo ./bulb --config bulb.config`

To check that the changes were successful,
check the directions of the pins in the configuration.

For example, to test the physical pin 12 (GPIO 18), run the following:
```
echo 18 > /sys/class/gpio/export
cat /sys/class/gpio/gpio18/direction
```

The output of the direction should be `out` since pin 12 (the A pin on the 7 segment display) was configured to be in the out direction.